### PR TITLE
Switch to stadtnavi tiles

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -107,7 +107,7 @@
             <h3 class="panel-title">Karte</h3>
           </div>
           <div class="panel-body">
-            Dank an <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="http://geodienste.lyrk.de/copyright">OpenStreetMap und andere</a>, Kacheln von <a href="http://geodienste.lyrk.de/">Lyrk</a>.
+            Dank an <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap Mitwirkende</a>, Kacheln von <a href="https://stadtnavi.de/">stadtnavi</a>.
           </div>
         </div>
       </div>

--- a/cs/contact.html
+++ b/cs/contact.html
@@ -107,7 +107,7 @@
             <h3 class="panel-title">Mapy</h3>
           </div>
           <div class="panel-body">
-            Díky patří <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="http://geodienste.lyrk.de/copyright">OpenStreetMap a dalším</a>, mapové dlaždice poskytuje <a href="http://geodienste.lyrk.de/">Lyrk</a>.
+            Díky patří <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="https://www.openstreetmap.org/copyright/">Přispěvatelé OpenStreetMap</a>, Dlaždice z <a href="https://stadtnavi.de/">stadtnavi</a>.
           </div>
         </div>
       </div>

--- a/en/contact.html
+++ b/en/contact.html
@@ -107,7 +107,7 @@
             <h3 class="panel-title">Map</h3>
           </div>
           <div class="panel-body">
-            Thanks to <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="http://geodienste.lyrk.de/copyright">OpenStreetMap and others</a>, Tiles by <a href="http://geodienste.lyrk.de/">Lyrk</a>.
+            Thanks to <a href="https://github.com/ubahnverleih/parkenDD">ubahnverleih</a>, <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap contributors</a>, Tiles by <a href="https://stadtnavi.de/">stadtnavi</a>.
           </div>
         </div>
       </div>

--- a/lib/css/parkendd.css
+++ b/lib/css/parkendd.css
@@ -37,3 +37,7 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+.marketing .col-lg-4 {
+  z-Index: 1000;
+}

--- a/lib/js/map.js
+++ b/lib/js/map.js
@@ -4,21 +4,21 @@ var translations = {
     noData: 'Keine Daten verfügbar.',
     available: '{} von {} Parkplätzen sind noch frei.',
     mapTitle: 'Karte - {}',
-    attribution: 'Attribution'
+    attribution: 'Daten: verschiedene Quellen, Hintergrundkarte: stadtnavi,© OpenStreetMap Mitwirkende'
   },
   en: {
     closed: 'Closed.',
     noData: 'No data available.',
-    available: '{} of {} parking lots are free.',
+    available: '{} of {} parking lots are available.',
     mapTitle: 'Map - {}',
-    attribution: 'Attribution'
+    attribution: 'data: various sources, background map: stadtnavi, © OpenStreetMap contributors'
   },
   cs: {
     closed: 'Zavřeno.',
     noData: 'Žádná dostupná data.',
     available: '{} z {} parkovacích míst volných.',
     mapTitle: 'Mapa - {}',
-    attribution: 'Přisuzování'
+    attribution: 'data: různé zdroje, podkladová mapa: stadtnavi, © přispěvatelé OpenStreetMap'
   }
 };
 

--- a/lib/js/map.js
+++ b/lib/js/map.js
@@ -199,12 +199,12 @@ function updateLinks (cityID, city) {
 
 function createMap () {
   var map = L.map('map');
-  var tp = 'ls';
+  var tp = '';
   if (L.Browser.retina) {
-    tp = 'lr';
+    tp = '@2x';
   }
   // var tilesUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
-  var tilesUrl = 'https://tiles.lyrk.org/' + tp + '/{z}/{x}/{y}?apikey=78be313986c84fbfa6c188a1d1385303';
+  var tilesUrl = 'https://tiles.stadtnavi.eu/streets/{z}/{x}/{y}'+tp+'.png';
   L.tileLayer(tilesUrl, {
     attribution: '<a href="contact.html#licenses">' + translate('attribution') + '</a>',
     maxZoom: 18


### PR DESCRIPTION
This PR replaces the currently not working lyrk tiles by stadtnavi tiles.

Additionally, the attribution is enhanced and states explicitly OpenStreetMap for the background map data.

<img width="1293" alt="image" src="https://github.com/offenesdresden/parkendd.de/assets/2187389/7e9efb69-dd89-4ecd-b057-aae5fa1accb5">
